### PR TITLE
Add manufactured solution stabilisation compatability

### DIFF
--- a/papers/JFNK_mixed/linearElastic/manufactoredSolution/Allrun
+++ b/papers/JFNK_mixed/linearElastic/manufactoredSolution/Allrun
@@ -14,8 +14,18 @@ source solids4FoamScripts.sh
 configs=(
     "BASE=base/snes NAME=hex.hypre USE_GMSH=0 USE_DUALMESH=0 USE_PERTURBMESHPOINTS=0 PETSC_FILE=petscOptions.split"
     #"BASE=base/snes NAME=tet.hypre USE_GMSH=1 USE_DUALMESH=0 USE_PERTURBMESHPOINTS=0 PETSC_FILE=petscOptions.split"
-    "BASE=base/snes NAME=poly.hypre USE_GMSH=1 USE_DUALMESH=1 USE_PERTURBMESHPOINTS=0 PETSC_FILE=petscOptions.split"
-    "BASE=base/snes NAME=distHex.hypre USE_GMSH=0 USE_DUALMESH=0 USE_PERTURBMESHPOINTS=1 PETSC_FILE=petscOptions.split"
+    #"BASE=base/snes NAME=poly.hypre USE_GMSH=1 USE_DUALMESH=1 USE_PERTURBMESHPOINTS=0 PETSC_FILE=petscOptions.split"
+    #"BASE=base/snes NAME=distHex.hypre USE_GMSH=0 USE_DUALMESH=0 USE_PERTURBMESHPOINTS=1 PETSC_FILE=petscOptions.split"
+)
+
+# Pressure stabilisation methods for the MMS stabilisation-framework check
+stabilisations=(
+    "STAB=rhiechow STAB_FILE=solidProperties.rhiechow"
+    "STAB=laplacian STAB_FILE=solidProperties.laplacian"
+    "STAB=jst STAB_FILE=solidProperties.jst"
+    "STAB=evenlap_m0 STAB_FILE=solidProperties.evenlap_m0"
+    "STAB=evenlap_m1 STAB_FILE=solidProperties.evenlap_m1"
+    "STAB=evenlap_m2 STAB_FILE=solidProperties.evenlap_m2"
 )
 # SNES segregated approach
 #    "BASE=base/snes NAME=hex.seg.hypre USE_GMSH=0 USE_DUALMESH=0 USE_PERTURBMESHPOINTS=0 PETSC_FILE=petscOptions.seg.hypre"
@@ -27,7 +37,7 @@ configs=(
 # Mesh input files are defined from 1 to 6
 # END_MESH should be greater than START_MESH
 START_MESH=1
-END_MESH=5
+END_MESH=4
 
 
 # Detect the CPU type: we append this to the case name
@@ -54,6 +64,16 @@ mkdir "${RUN_DIR}"
 # Enter the run directory
 cd "${RUN_DIR}"
 
+for stabConfig in "${stabilisations[@]}"
+do
+    eval $stabConfig
+    echo; echo "***************************************"
+    echo "Running pressure stabilisation: ${STAB}"
+    echo "***************************************"
+
+    mkdir "${STAB}"
+    cd "${STAB}"
+
 # Iterate through configurations
 for config in "${configs[@]}"
 do
@@ -67,7 +87,6 @@ do
     # Define results summary file name
     SUMMARY="${NAME}.summary.txt"
     echo "# Mesh Time Mem D_L2 D_Linf S_L2 S_Linf" > "${SUMMARY}"
-
     # Loop over mesh densities in each configuration
     for i in `seq $START_MESH $END_MESH`
     do
@@ -75,8 +94,9 @@ do
         echo; echo "Processing case: $CASE"
 
         # Prepare the case
-        cp -r "../${BASE}" "${CASE}"
+        cp -r "../../${BASE}" "${CASE}"
         cd "$CASE"
+        cp "constant/${STAB_FILE}" "constant/solidProperties"
 
         # Mesh generation logic
         if [ "$USE_GMSH" -eq 1 ]
@@ -122,7 +142,9 @@ do
 
         # Update the PETSc options file
         if [ -n "${PETSC_FILE}" ]; then
-            sed -i "/^\s*optionsFile /s|^.*|    optionsFile ${PETSC_FILE};|" constant/solidProperties
+            foamDictionary constant/solidProperties \
+                -entry linearGeometryTotalDisplacementCoeffs.optionsFile \
+                -set "${PETSC_FILE}"
         fi
 
         # Run the solver
@@ -132,15 +154,24 @@ do
         then
             echo "Running solids4Foam on ${CASE} with gtime"
             gtime -f "Maximum resident set size (kbytes): %M" mpirun -np 1 solids4Foam &> log.solids4Foam
-        elif command -v time &> /dev/null
+            SOLVER_STATUS=$?
+        elif command -v /usr/bin/time &> /dev/null && /usr/bin/time -f "Maximum resident set size (kbytes): %M" true &> /dev/null
         then
             echo "Running solids4Foam on ${CASE} with time"
-            gtime -f "Maximum resident set size (kbytes): %M" mpirun -np 1 solids4Foam &> log.solids4Foam
+            /usr/bin/time -f "Maximum resident set size (kbytes): %M" mpirun -np 1 solids4Foam &> log.solids4Foam
+            SOLVER_STATUS=$?
         else
             echo "Running solids4Foam on ${CASE}"
             # Strange PETSc issue on Macbook where I need to use mpirun for serial
             #solids4Foam::runApplication solids4Foam
             mpirun -np 1 solids4Foam &> log.solids4Foam
+            SOLVER_STATUS=$?
+        fi
+
+        if [ "$SOLVER_STATUS" -ne 0 ]
+        then
+            echo "solids4Foam failed for ${CASE}; see ${PWD}/log.solids4Foam"
+            exit "$SOLVER_STATUS"
         fi
 
         # Extract results from solver log and append them to a summary file
@@ -183,11 +214,17 @@ do
     cat "${ORDER}"
 done
 
+    cd ..
+done
+
 # Create plots if gnuplot in installed
 if command -v gnuplot &>/dev/null
 then
     # Copy gnuplot scripts
-    cp ../plotScripts/*gnuplot .
+    cp ../plotScripts/dispErrors.gnuplot .
+    cp ../plotScripts/stressErrors.gnuplot .
+    cp ../plotScripts/orderOfAccuracyDisp.gnuplot .
+    cp ../plotScripts/orderOfAccuracyStress.gnuplot .
     cp ../plotScripts/orderOfAccuracySlopes*.dat .
 
     # Run all scripts
@@ -196,50 +233,6 @@ then
         echo "Running gnuplot on $f"
         gnuplot "$f"
     done
-fi
-
-# Extract comparison of JFNK and segregated for the hex meshes
-if [[ -f hex.hypre.summary.txt && -f hex.seg.summary.txt ]]
-then
-    # Define input files
-    FILE1="hex.hypre.summary.txt"
-    FILE2="hex.seg.summary.txt"
-    OUTPUT="tableJFNKvsSeg_mms.tex"
-
-    # Define mesh sizes for the rows in the table
-    MESH_SIZES=("125" "\$1\,000\$" "\$8\,000\$" "\$64\,000\$" "\$512\,000\$" "\$4\,096\,000\$")
-
-    # Extract columns and write to the output file
-    {
-        for i in $(seq 1 $((${#MESH_SIZES[@]})))
-        do
-            # Extract columns 2 and 3 from each file
-            F1C2=$(awk "NR==$((i + 1)) {print \$2}" "$FILE1")
-            F1C3=$(awk "NR==$((i + 1)) {print \$3}" "$FILE1")
-            F2C2=$(awk "NR==$((i + 1)) {print \$2}" "$FILE2")
-            F2C3=$(awk "NR==$((i + 1)) {print \$3}" "$FILE2")
-
-            if [[ i -eq 1 ]]
-            then
-                echo -e "\t\\\textbf{MMS}\t\t& ${MESH_SIZES[i-1]}\t& $F1C2 & $F1C3 & $F2C2 & $F2C3 \\\\\\"
-            elif [[ i -eq 2 ]]
-            then
-                echo -e "\t\\emph{regular hex}\t& ${MESH_SIZES[i-1]}\t& $F1C2 & $F1C3 & $F2C2 & $F2C3 \\\\\\"
-            elif [[ i -eq 3 ]]
-            then
-                echo -e "\t\\emph{3-D, static}\t& ${MESH_SIZES[i-1]}\t& $F1C2 & $F1C3 & $F2C2 & $F2C3 \\\\\\"
-            elif [[ i -eq 4 ]]
-            then
-                echo -e "\t\\emph{linear elastic}\t& ${MESH_SIZES[i-1]}\t& $F1C2 & $F1C3 & $F2C2 & $F2C3 \\\\\\"
-            else
-                echo -e "\t\t\t\t& ${MESH_SIZES[i-1]}\t& $F1C2 & $F1C3 & $F2C2 & $F2C3 \\\\\\"
-            fi
-        done
-    } > "$OUTPUT"
-
-    echo -e "\hline" >> "$OUTPUT"
-
-    echo; echo "Table generated in $OUTPUT"
 fi
 
 # Exit the run directory

--- a/papers/JFNK_mixed/linearElastic/manufactoredSolution/README.md
+++ b/papers/JFNK_mixed/linearElastic/manufactoredSolution/README.md
@@ -17,12 +17,19 @@ export SOLIDS4FOAM_DIR=/Users/philipc/OpenFOAM/philipc-v2312/solids4foam
 ```
 The `manufacturedSolution` library can then be compiled with
 ```bash
-(cd manufacturedSolution && ./Allwmake -j -s)
+(cd ../manufacturedSolution && ./Allwmake -j -s)
 ```
 
 ### Run the Cases
-The `Allrun` runs the a mesh study for various mesh and solution procedure
-configurations. The configurations are defined near the top of the `Allrun` script:
+The `Allrun` runs a mesh study for each pressure stabilisation method used in
+the Cook's membrane study:
+
+```bash
+rhiechow laplacian jst evenlap_m0 evenlap_m1 evenlap_m2
+```
+
+The mesh and solution procedure configurations are defined near the top of the
+`Allrun` script:
 ```bash
 configs=(
     "BASE=base/snes NAME=hex.hypre USE_GMSH=0 USE_DUALMESH=0 USE_PERTURBMESHPOINTS=0 PETSC_FILE=petscOptions.hypre"
@@ -38,6 +45,7 @@ The `Allrun` script is executed as
 ./Allrun
 ```
 which creates a directory for the cases called `run_<CPU_NAME>_<DATE_TIME>`, for
-example, `run_Apple_M1_Ultra_20250118_151956`. When the `Allrun` script
-completes, pdf plots will be available in the directory, if `gnuplot` is
-installed.
+example, `run_Apple_M1_Ultra_20250118_151956`. The results for each pressure
+stabilisation are written in sub-directories named after the stabilisation
+method. When the `Allrun` script completes, pdf plots will be available in each
+method directory, if `gnuplot` is installed.

--- a/papers/JFNK_mixed/linearElastic/manufactoredSolution/base/snes/constant/fvOptions
+++ b/papers/JFNK_mixed/linearElastic/manufactoredSolution/base/snes/constant/fvOptions
@@ -20,9 +20,11 @@ momentumSource
     fields          (D);
     E               200e9;
     nu              0.3;
-    ax              2e-6;
-    ay              4e-6;
-    az              6e-6;
+    // The analytical fields in controlDict use positive coefficients.
+    // The source uses the opposite sign for the current SNES residual convention.
+    ax              -2e-6;
+    ay              -4e-6;
+    az              -6e-6;
 }
 
 

--- a/papers/JFNK_mixed/linearElastic/manufactoredSolution/base/snes/constant/solidProperties.evenlap_m0
+++ b/papers/JFNK_mixed/linearElastic/manufactoredSolution/base/snes/constant/solidProperties.evenlap_m0
@@ -4,7 +4,7 @@
 | Web:         https://solids4foam.github.io                                  |
 | Disclaimer:  This offering is not approved or endorsed by OpenCFD Limited,  |
 |              producer and distributor of the OpenFOAM software via          |
-|              www.openfoam.com, and owner of the OPENFOAM® and OpenCFD®      |
+|              www.openfoam.com, and owner of the OPENFOAM(R) and OpenCFD(R)  |
 |              trade marks.                                                   |
 \*---------------------------------------------------------------------------*/
 FoamFile
@@ -35,9 +35,9 @@ linearGeometryTotalDisplacementCoeffs
 
     preconditioner
     {
-	// The "simplifiedEquation" approach solves a simple Laplace equation,
-	// while the non-basic approach solves the full solid mechanics system
-	simplifiedEquation yes;
+        // The "simplifiedEquation" approach solves a simple Laplace equation,
+        // while the non-basic approach solves the full solid mechanics system
+        simplifiedEquation yes;
     }
     solvePressure true;
 
@@ -51,9 +51,10 @@ linearGeometryTotalDisplacementCoeffs
 
         pressure
         {
-            type                laplacian;
+            type                generalisedEvenOrderLaplacian;
             scaleFactor         0.125;
-            scaleFactorJacobian 0.75;
+            scaleFactorJacobian 0.25;
+            laplacianPower      0;
         }
     }
 

--- a/papers/JFNK_mixed/linearElastic/manufactoredSolution/base/snes/constant/solidProperties.evenlap_m1
+++ b/papers/JFNK_mixed/linearElastic/manufactoredSolution/base/snes/constant/solidProperties.evenlap_m1
@@ -4,7 +4,7 @@
 | Web:         https://solids4foam.github.io                                  |
 | Disclaimer:  This offering is not approved or endorsed by OpenCFD Limited,  |
 |              producer and distributor of the OpenFOAM software via          |
-|              www.openfoam.com, and owner of the OPENFOAM® and OpenCFD®      |
+|              www.openfoam.com, and owner of the OPENFOAM(R) and OpenCFD(R)  |
 |              trade marks.                                                   |
 \*---------------------------------------------------------------------------*/
 FoamFile
@@ -35,9 +35,9 @@ linearGeometryTotalDisplacementCoeffs
 
     preconditioner
     {
-	// The "simplifiedEquation" approach solves a simple Laplace equation,
-	// while the non-basic approach solves the full solid mechanics system
-	simplifiedEquation yes;
+        // The "simplifiedEquation" approach solves a simple Laplace equation,
+        // while the non-basic approach solves the full solid mechanics system
+        simplifiedEquation yes;
     }
     solvePressure true;
 
@@ -51,9 +51,10 @@ linearGeometryTotalDisplacementCoeffs
 
         pressure
         {
-            type                laplacian;
+            type                generalisedEvenOrderLaplacian;
             scaleFactor         0.125;
-            scaleFactorJacobian 0.75;
+            scaleFactorJacobian 1.0;
+            laplacianPower      1;
         }
     }
 

--- a/papers/JFNK_mixed/linearElastic/manufactoredSolution/base/snes/constant/solidProperties.evenlap_m2
+++ b/papers/JFNK_mixed/linearElastic/manufactoredSolution/base/snes/constant/solidProperties.evenlap_m2
@@ -4,7 +4,7 @@
 | Web:         https://solids4foam.github.io                                  |
 | Disclaimer:  This offering is not approved or endorsed by OpenCFD Limited,  |
 |              producer and distributor of the OpenFOAM software via          |
-|              www.openfoam.com, and owner of the OPENFOAM® and OpenCFD®      |
+|              www.openfoam.com, and owner of the OPENFOAM(R) and OpenCFD(R)  |
 |              trade marks.                                                   |
 \*---------------------------------------------------------------------------*/
 FoamFile
@@ -35,9 +35,9 @@ linearGeometryTotalDisplacementCoeffs
 
     preconditioner
     {
-	// The "simplifiedEquation" approach solves a simple Laplace equation,
-	// while the non-basic approach solves the full solid mechanics system
-	simplifiedEquation yes;
+        // The "simplifiedEquation" approach solves a simple Laplace equation,
+        // while the non-basic approach solves the full solid mechanics system
+        simplifiedEquation yes;
     }
     solvePressure true;
 
@@ -51,9 +51,10 @@ linearGeometryTotalDisplacementCoeffs
 
         pressure
         {
-            type                laplacian;
-            scaleFactor         0.125;
-            scaleFactorJacobian 0.75;
+            type                generalisedEvenOrderLaplacian;
+            scaleFactor         1.0;
+            scaleFactorJacobian 1.0;
+            laplacianPower      2;
         }
     }
 

--- a/papers/JFNK_mixed/linearElastic/manufactoredSolution/base/snes/constant/solidProperties.jst
+++ b/papers/JFNK_mixed/linearElastic/manufactoredSolution/base/snes/constant/solidProperties.jst
@@ -4,7 +4,7 @@
 | Web:         https://solids4foam.github.io                                  |
 | Disclaimer:  This offering is not approved or endorsed by OpenCFD Limited,  |
 |              producer and distributor of the OpenFOAM software via          |
-|              www.openfoam.com, and owner of the OPENFOAM® and OpenCFD®      |
+|              www.openfoam.com, and owner of the OPENFOAM(R) and OpenCFD(R)  |
 |              trade marks.                                                   |
 \*---------------------------------------------------------------------------*/
 FoamFile
@@ -35,9 +35,9 @@ linearGeometryTotalDisplacementCoeffs
 
     preconditioner
     {
-	// The "simplifiedEquation" approach solves a simple Laplace equation,
-	// while the non-basic approach solves the full solid mechanics system
-	simplifiedEquation yes;
+        // The "simplifiedEquation" approach solves a simple Laplace equation,
+        // while the non-basic approach solves the full solid mechanics system
+        simplifiedEquation yes;
     }
     solvePressure true;
 
@@ -51,9 +51,9 @@ linearGeometryTotalDisplacementCoeffs
 
         pressure
         {
-            type                laplacian;
+            type                JamesonSchmidtTurkel;
             scaleFactor         0.125;
-            scaleFactorJacobian 0.75;
+            scaleFactorJacobian 1.0;
         }
     }
 

--- a/papers/JFNK_mixed/linearElastic/manufactoredSolution/base/snes/constant/solidProperties.laplacian
+++ b/papers/JFNK_mixed/linearElastic/manufactoredSolution/base/snes/constant/solidProperties.laplacian
@@ -4,7 +4,7 @@
 | Web:         https://solids4foam.github.io                                  |
 | Disclaimer:  This offering is not approved or endorsed by OpenCFD Limited,  |
 |              producer and distributor of the OpenFOAM software via          |
-|              www.openfoam.com, and owner of the OPENFOAM® and OpenCFD®      |
+|              www.openfoam.com, and owner of the OPENFOAM(R) and OpenCFD(R)  |
 |              trade marks.                                                   |
 \*---------------------------------------------------------------------------*/
 FoamFile
@@ -35,9 +35,9 @@ linearGeometryTotalDisplacementCoeffs
 
     preconditioner
     {
-	// The "simplifiedEquation" approach solves a simple Laplace equation,
-	// while the non-basic approach solves the full solid mechanics system
-	simplifiedEquation yes;
+        // The "simplifiedEquation" approach solves a simple Laplace equation,
+        // while the non-basic approach solves the full solid mechanics system
+        simplifiedEquation yes;
     }
     solvePressure true;
 

--- a/papers/JFNK_mixed/linearElastic/manufactoredSolution/base/snes/constant/solidProperties.rhiechow
+++ b/papers/JFNK_mixed/linearElastic/manufactoredSolution/base/snes/constant/solidProperties.rhiechow
@@ -4,7 +4,7 @@
 | Web:         https://solids4foam.github.io                                  |
 | Disclaimer:  This offering is not approved or endorsed by OpenCFD Limited,  |
 |              producer and distributor of the OpenFOAM software via          |
-|              www.openfoam.com, and owner of the OPENFOAM® and OpenCFD®      |
+|              www.openfoam.com, and owner of the OPENFOAM(R) and OpenCFD(R)  |
 |              trade marks.                                                   |
 \*---------------------------------------------------------------------------*/
 FoamFile
@@ -35,9 +35,9 @@ linearGeometryTotalDisplacementCoeffs
 
     preconditioner
     {
-	// The "simplifiedEquation" approach solves a simple Laplace equation,
-	// while the non-basic approach solves the full solid mechanics system
-	simplifiedEquation yes;
+        // The "simplifiedEquation" approach solves a simple Laplace equation,
+        // while the non-basic approach solves the full solid mechanics system
+        simplifiedEquation yes;
     }
     solvePressure true;
 
@@ -51,9 +51,9 @@ linearGeometryTotalDisplacementCoeffs
 
         pressure
         {
-            type                laplacian;
-            scaleFactor         0.125;
-            scaleFactorJacobian 0.75;
+            type                RhieChow;
+            scaleFactor         1.0;
+            scaleFactorJacobian 1.0;
         }
     }
 

--- a/papers/JFNK_mixed/linearElastic/manufactoredSolution/base/snes/petscOptions.split
+++ b/papers/JFNK_mixed/linearElastic/manufactoredSolution/base/snes/petscOptions.split
@@ -2,12 +2,13 @@
 # The default line search may sometimes fail; in that case, switch to "basic"
 -snes_type newtonls
 -snes_linesearch_type l2
--snes_linesearch_damping 0.2
+-snes_linesearch_damping 0.1
 -snes_rtol 1e-6
 -snes_stol 1e-6
 -snes_max_it 1000
 -snes_monitor
 -snes_converged_reason
+-snes_divergence_tolerance 1e12
 #-snes_test_jacobian
 #-snes_test_jacobian_view
 

--- a/papers/JFNK_mixed/linearElastic/manufactoredSolution/plotScripts/dispErrors.gnuplot
+++ b/papers/JFNK_mixed/linearElastic/manufactoredSolution/plotScripts/dispErrors.gnuplot
@@ -3,22 +3,18 @@ set datafile separator " "
 
 set output "mms_dispErrors.pdf"
 
-#set size ratio 1
-
 set grid
 set xrange [1:50]
-set yrange [1e-5:1.0]
+set yrange [1e-6:1.0]
 set xtics
 set xtics add (5, 25, 50)
 set ytics
 set logscale x
 set logscale y
 set format y "10^{%L}"
-#set ytics 0.002
 set xlabel "Average cell spacing (in mm)"
-set ylabel "Error (in μm)"
-#set key left top;
-set key right bottom;
+set ylabel "Error (in um)"
+set key right bottom
 
 set label "1^{st} order" at graph 0.5,0.86 center rotate by 10
 set label "2^{nd} order" at graph 0.5,0.37 center rotate by 25
@@ -26,18 +22,19 @@ set label "2^{nd} order" at graph 0.5,0.37 center rotate by 25
 # Average mesh spacing of mesh1
 dx=0.04
 
-# 15,14 - upturned solid penta
-# 5,4 - square
-
-# Assume the mesh spacing is being halved for each succesive mesh
+# Assume the mesh spacing is being halved for each successive mesh
 plot \
-    "tet.hypre.summary.txt" u (1e3*dx/(2**($0))):(1e6*$4) w lp pt 9 lc "green" t "L_2 - Tet", \
-    "tet.hypre.summary.txt" u (1e3*dx/(2**($0))):(1e6*$5) w lp pt 8 lc "green" t "L_∞ - Tet", \
-    "poly.hypre.summary.txt" u (1e3*dx/(2**($0))):(1e6*$4) pt 15 lc "blue" w lp t "L_2 - Poly", \
-    "poly.hypre.summary.txt" u (1e3*dx/(2**($0))):(1e6*$5) pt 14 lc "blue" w lp t "L_∞ - Poly", \
-    "hex.hypre.summary.txt" u (1e3*dx/(2**($0))):(1e6*$4) w lp pt 5 lc "red" t "L_2 - Hex", \
-    "hex.hypre.summary.txt" u (1e3*dx/(2**($0))):(1e6*$5) w lp pt 4 lc "red" t "L_∞ - Hex", \
-    "distHex.hypre.summary.txt" u (1e3*dx/(2**($0))):(1e6*$4) w lp pt 28 lc rgb "#800080" t "L_2 - Hex (distorted)", \
-    "distHex.hypre.summary.txt" u (1e3*dx/(2**($0))):(1e6*$5) w lp pt 27 lc rgb "#800080" t "L_∞ - Hex (distorted)", \
+    "rhiechow/hex.hypre.summary.txt" u (1e3*dx/(2**($1-1))):(1e6*$4) w lp pt 5 lc rgb "#d7191c" t "L_2 - RhieChow", \
+    "rhiechow/hex.hypre.summary.txt" u (1e3*dx/(2**($1-1))):(1e6*$5) w lp pt 4 lc rgb "#d7191c" t "L_inf - RhieChow", \
+    "laplacian/hex.hypre.summary.txt" u (1e3*dx/(2**($1-1))):(1e6*$4) w lp pt 7 lc rgb "#2c7bb6" t "L_2 - Laplacian", \
+    "laplacian/hex.hypre.summary.txt" u (1e3*dx/(2**($1-1))):(1e6*$5) w lp pt 6 lc rgb "#2c7bb6" t "L_inf - Laplacian", \
+    "jst/hex.hypre.summary.txt" u (1e3*dx/(2**($1-1))):(1e6*$4) w lp pt 9 lc rgb "#fdae61" t "L_2 - JST", \
+    "jst/hex.hypre.summary.txt" u (1e3*dx/(2**($1-1))):(1e6*$5) w lp pt 8 lc rgb "#fdae61" t "L_inf - JST", \
+    "evenlap_m0/hex.hypre.summary.txt" u (1e3*dx/(2**($1-1))):(1e6*$4) w lp pt 11 lc rgb "#abd9e9" t "L_2 - EvenLap m0", \
+    "evenlap_m0/hex.hypre.summary.txt" u (1e3*dx/(2**($1-1))):(1e6*$5) w lp pt 10 lc rgb "#abd9e9" t "L_inf - EvenLap m0", \
+    "evenlap_m1/hex.hypre.summary.txt" u (1e3*dx/(2**($1-1))):(1e6*$4) w lp pt 13 lc rgb "#2ca25f" t "L_2 - EvenLap m1", \
+    "evenlap_m1/hex.hypre.summary.txt" u (1e3*dx/(2**($1-1))):(1e6*$5) w lp pt 12 lc rgb "#2ca25f" t "L_inf - EvenLap m1", \
+    "evenlap_m2/hex.hypre.summary.txt" u (1e3*dx/(2**($1-1))):(1e6*$4) w lp pt 15 lc rgb "#756bb1" t "L_2 - EvenLap m2", \
+    "evenlap_m2/hex.hypre.summary.txt" u (1e3*dx/(2**($1-1))):(1e6*$5) w lp pt 14 lc rgb "#756bb1" t "L_inf - EvenLap m2", \
     "orderOfAccuracySlopesDisp.dat" u 1:(2.8*$2) w l lw 2 lc "black" notitle, \
     "orderOfAccuracySlopesDisp.dat" u 1:3 w l lw 2 lc "black" notitle

--- a/papers/JFNK_mixed/linearElastic/manufactoredSolution/plotScripts/orderOfAccuracyDisp.gnuplot
+++ b/papers/JFNK_mixed/linearElastic/manufactoredSolution/plotScripts/orderOfAccuracyDisp.gnuplot
@@ -10,23 +10,24 @@ set xtics
 set xtics add (5, 25, 50)
 set ytics
 set logscale x
-#set logscale y
-#set ytics 0.002
 set xlabel "Average cell spacing (in mm)"
 set ylabel "Order of accuracy"
-set key bottom left;
+set key bottom left
 
 # Average mesh spacing of mesh1
 dx=0.04
 
-# Assume the mesh spacing is being halved for each succesive mesh
+# Assume the mesh spacing is being halved for each successive mesh
 plot \
-    "tet.hypre.orderOfAccuracy.txt" using (1e3*dx/(2**($0+1))):2 skip 1 w lp pt 9 lc "green" t "L_2 - Tet", \
-    "tet.hypre.orderOfAccuracy.txt" using (1e3*dx/(2**($0+1))):3 skip 1 w lp pt 8 lc "green" t "L_∞ - Tet", \
-    "poly.hypre.orderOfAccuracy.txt" using (1e3*dx/(2**($0+1))):2 skip 1 w lp pt 15 lc "blue" t "L_2 - Poly", \
-    "poly.hypre.orderOfAccuracy.txt" using (1e3*dx/(2**($0+1))):3 skip 1 w lp pt 14 lc "blue" t "L_∞ - Poly", \
-    "hex.hypre.orderOfAccuracy.txt" using (1e3*dx/(2**($0+1))):2 skip 1 w lp pt 5 lc "red" t "L_2 - Hex", \
-    "hex.hypre.orderOfAccuracy.txt" using (1e3*dx/(2**($0+1))):3 skip 1 w lp pt 4 lc "red" t "L_∞ - Hex", \
-    "distHex.hypre.orderOfAccuracy.txt" using (1e3*dx/(2**($0+1))):2 skip 1 w lp pt 28 lc rgb "#800080" t "L_2 - Hex (distorted)", \
-    "distHex.hypre.orderOfAccuracy.txt" using (1e3*dx/(2**($0+1))):3 skip 1 w lp pt 27 lc rgb "#800080" t "L_∞ - Hex (distorted)"
-
+    "rhiechow/hex.hypre.orderOfAccuracy.txt" u (1e3*dx/(2**($1))):2 w lp pt 5 lc rgb "#d7191c" t "L_2 - RhieChow", \
+    "rhiechow/hex.hypre.orderOfAccuracy.txt" u (1e3*dx/(2**($1))):3 w lp pt 4 lc rgb "#d7191c" t "L_inf - RhieChow", \
+    "laplacian/hex.hypre.orderOfAccuracy.txt" u (1e3*dx/(2**($1))):2 w lp pt 7 lc rgb "#2c7bb6" t "L_2 - Laplacian", \
+    "laplacian/hex.hypre.orderOfAccuracy.txt" u (1e3*dx/(2**($1))):3 w lp pt 6 lc rgb "#2c7bb6" t "L_inf - Laplacian", \
+    "jst/hex.hypre.orderOfAccuracy.txt" u (1e3*dx/(2**($1))):2 w lp pt 9 lc rgb "#fdae61" t "L_2 - JST", \
+    "jst/hex.hypre.orderOfAccuracy.txt" u (1e3*dx/(2**($1))):3 w lp pt 8 lc rgb "#fdae61" t "L_inf - JST", \
+    "evenlap_m0/hex.hypre.orderOfAccuracy.txt" u (1e3*dx/(2**($1))):2 w lp pt 11 lc rgb "#abd9e9" t "L_2 - EvenLap m0", \
+    "evenlap_m0/hex.hypre.orderOfAccuracy.txt" u (1e3*dx/(2**($1))):3 w lp pt 10 lc rgb "#abd9e9" t "L_inf - EvenLap m0", \
+    "evenlap_m1/hex.hypre.orderOfAccuracy.txt" u (1e3*dx/(2**($1))):2 w lp pt 13 lc rgb "#2ca25f" t "L_2 - EvenLap m1", \
+    "evenlap_m1/hex.hypre.orderOfAccuracy.txt" u (1e3*dx/(2**($1))):3 w lp pt 12 lc rgb "#2ca25f" t "L_inf - EvenLap m1", \
+    "evenlap_m2/hex.hypre.orderOfAccuracy.txt" u (1e3*dx/(2**($1))):2 w lp pt 15 lc rgb "#756bb1" t "L_2 - EvenLap m2", \
+    "evenlap_m2/hex.hypre.orderOfAccuracy.txt" u (1e3*dx/(2**($1))):3 w lp pt 14 lc rgb "#756bb1" t "L_inf - EvenLap m2"

--- a/papers/JFNK_mixed/linearElastic/manufactoredSolution/plotScripts/orderOfAccuracyStress.gnuplot
+++ b/papers/JFNK_mixed/linearElastic/manufactoredSolution/plotScripts/orderOfAccuracyStress.gnuplot
@@ -10,8 +10,6 @@ set xtics
 set xtics add (5, 25, 50)
 set ytics
 set logscale x
-#set logscale y
-#set ytics 0.002
 set xlabel "Average cell spacing (in mm)"
 set ylabel "Order of accuracy"
 set key bottom right
@@ -19,14 +17,17 @@ set key bottom right
 # Average mesh spacing of mesh1
 dx=0.04
 
-# Assume the mesh spacing is being halved for each succesive mesh
+# Assume the mesh spacing is being halved for each successive mesh
 plot \
-    "tet.hypre.orderOfAccuracy.txt" using (1e3*dx/(2**($0+1))):4 skip 1 w lp pt 9 lc "green" t "L_2 - Tet", \
-    "tet.hypre.orderOfAccuracy.txt" using (1e3*dx/(2**($0+1))):5 skip 1 w lp pt 8 lc "green" t "L_∞ - Tet", \
-    "poly.hypre.orderOfAccuracy.txt" using (1e3*dx/(2**($0+1))):4 skip 1 w lp pt 15 lc "blue" t "L_2 - Poly", \
-    "poly.hypre.orderOfAccuracy.txt" using (1e3*dx/(2**($0+1))):5 skip 1 w lp pt 14 lc "blue" t "L_∞ - Poly", \
-    "hex.hypre.orderOfAccuracy.txt" using (1e3*dx/(2**($0+1))):4 skip 1 w lp pt 5 lc "red" t "L_2 - Hex", \
-    "hex.hypre.orderOfAccuracy.txt" using (1e3*dx/(2**($0+1))):5 skip 1 w lp pt 4 lc "red" t "L_∞ - Hex", \
-    "distHex.hypre.orderOfAccuracy.txt" using (1e3*dx/(2**($0+1))):4 skip 1 w lp pt 28 lc rgb "#800080" t "L_2 - Hex (distorted)", \
-    "distHex.hypre.orderOfAccuracy.txt" using (1e3*dx/(2**($0+1))):5 skip 1 w lp pt 27 lc rgb "#800080" t "L_∞ - Hex (distorted)", \
-
+    "rhiechow/hex.hypre.orderOfAccuracy.txt" u (1e3*dx/(2**($1))):4 w lp pt 5 lc rgb "#d7191c" t "L_2 - RhieChow", \
+    "rhiechow/hex.hypre.orderOfAccuracy.txt" u (1e3*dx/(2**($1))):5 w lp pt 4 lc rgb "#d7191c" t "L_inf - RhieChow", \
+    "laplacian/hex.hypre.orderOfAccuracy.txt" u (1e3*dx/(2**($1))):4 w lp pt 7 lc rgb "#2c7bb6" t "L_2 - Laplacian", \
+    "laplacian/hex.hypre.orderOfAccuracy.txt" u (1e3*dx/(2**($1))):5 w lp pt 6 lc rgb "#2c7bb6" t "L_inf - Laplacian", \
+    "jst/hex.hypre.orderOfAccuracy.txt" u (1e3*dx/(2**($1))):4 w lp pt 9 lc rgb "#fdae61" t "L_2 - JST", \
+    "jst/hex.hypre.orderOfAccuracy.txt" u (1e3*dx/(2**($1))):5 w lp pt 8 lc rgb "#fdae61" t "L_inf - JST", \
+    "evenlap_m0/hex.hypre.orderOfAccuracy.txt" u (1e3*dx/(2**($1))):4 w lp pt 11 lc rgb "#abd9e9" t "L_2 - EvenLap m0", \
+    "evenlap_m0/hex.hypre.orderOfAccuracy.txt" u (1e3*dx/(2**($1))):5 w lp pt 10 lc rgb "#abd9e9" t "L_inf - EvenLap m0", \
+    "evenlap_m1/hex.hypre.orderOfAccuracy.txt" u (1e3*dx/(2**($1))):4 w lp pt 13 lc rgb "#2ca25f" t "L_2 - EvenLap m1", \
+    "evenlap_m1/hex.hypre.orderOfAccuracy.txt" u (1e3*dx/(2**($1))):5 w lp pt 12 lc rgb "#2ca25f" t "L_inf - EvenLap m1", \
+    "evenlap_m2/hex.hypre.orderOfAccuracy.txt" u (1e3*dx/(2**($1))):4 w lp pt 15 lc rgb "#756bb1" t "L_2 - EvenLap m2", \
+    "evenlap_m2/hex.hypre.orderOfAccuracy.txt" u (1e3*dx/(2**($1))):5 w lp pt 14 lc rgb "#756bb1" t "L_inf - EvenLap m2"

--- a/papers/JFNK_mixed/linearElastic/manufactoredSolution/plotScripts/stressErrors.gnuplot
+++ b/papers/JFNK_mixed/linearElastic/manufactoredSolution/plotScripts/stressErrors.gnuplot
@@ -3,8 +3,6 @@ set datafile separator " "
 
 set output "mms_stressErrors_v2.pdf"
 
-#set size ratio 1
-
 set grid
 set xrange [1:50]
 set yrange [0.001:10]
@@ -14,11 +12,9 @@ set ytics
 set logscale x
 set logscale y
 set format y "10^{%L}"
-#set ytics 0.002
 set xlabel "Average cell spacing (in mm)"
 set ylabel "Error (in MPa)"
-#set key left top;
-set key right bottom;
+set key right bottom
 
 set label "1^{st} order" at graph 0.5,0.78 center rotate by 10
 set label "2^{nd} order" at graph 0.5,0.264 center rotate by 25
@@ -26,15 +22,19 @@ set label "2^{nd} order" at graph 0.5,0.264 center rotate by 25
 # Average mesh spacing of mesh1
 dx=0.04
 
-# Assume the mesh spacing is being halved for each succesive mesh
+# Assume the mesh spacing is being halved for each successive mesh
 plot \
-    "tet.hypre.summary.txt" u (1e3*dx/(2**($0))):(1e-6*$6) w lp pt 9 lc "green" t "L_2 - Tet", \
-    "tet.hypre.summary.txt" u (1e3*dx/(2**($0))):(1e-6*$7) w lp pt 8 lc "green" t "L_∞ - Tet", \
-    "poly.hypre.summary.txt" u (1e3*dx/(2**($0))):(1e-6*$6) pt 15 lc "blue" w lp t "L_2 - Poly", \
-    "poly.hypre.summary.txt" u (1e3*dx/(2**($0))):(1e-6*$7) pt 14 lc "blue" w lp t "L_∞ - Poly", \
-    "hex.hypre.summary.txt" u (1e3*dx/(2**($0))):(1e-6*$6) w lp pt 5 lc "red" t "L_2 - Hex", \
-    "hex.hypre.summary.txt" u (1e3*dx/(2**($0))):(1e-6*$7) w lp pt 4 lc "red" t "L_∞ - Hex", \
-    "distHex.hypre.summary.txt" u (1e3*dx/(2**($0))):(1e-6*$6) w lp pt 28 lc rgb "#800080" t "L_2 - Hex (distorted)", \
-    "distHex.hypre.summary.txt" u (1e3*dx/(2**($0))):(1e-6*$7) w lp pt 27 lc rgb "#800080" t "L_∞ - Hex (distorted)", \
+    "rhiechow/hex.hypre.summary.txt" u (1e3*dx/(2**($1-1))):(1e-6*$6) w lp pt 5 lc rgb "#d7191c" t "L_2 - RhieChow", \
+    "rhiechow/hex.hypre.summary.txt" u (1e3*dx/(2**($1-1))):(1e-6*$7) w lp pt 4 lc rgb "#d7191c" t "L_inf - RhieChow", \
+    "laplacian/hex.hypre.summary.txt" u (1e3*dx/(2**($1-1))):(1e-6*$6) w lp pt 7 lc rgb "#2c7bb6" t "L_2 - Laplacian", \
+    "laplacian/hex.hypre.summary.txt" u (1e3*dx/(2**($1-1))):(1e-6*$7) w lp pt 6 lc rgb "#2c7bb6" t "L_inf - Laplacian", \
+    "jst/hex.hypre.summary.txt" u (1e3*dx/(2**($1-1))):(1e-6*$6) w lp pt 9 lc rgb "#fdae61" t "L_2 - JST", \
+    "jst/hex.hypre.summary.txt" u (1e3*dx/(2**($1-1))):(1e-6*$7) w lp pt 8 lc rgb "#fdae61" t "L_inf - JST", \
+    "evenlap_m0/hex.hypre.summary.txt" u (1e3*dx/(2**($1-1))):(1e-6*$6) w lp pt 11 lc rgb "#abd9e9" t "L_2 - EvenLap m0", \
+    "evenlap_m0/hex.hypre.summary.txt" u (1e3*dx/(2**($1-1))):(1e-6*$7) w lp pt 10 lc rgb "#abd9e9" t "L_inf - EvenLap m0", \
+    "evenlap_m1/hex.hypre.summary.txt" u (1e3*dx/(2**($1-1))):(1e-6*$6) w lp pt 13 lc rgb "#2ca25f" t "L_2 - EvenLap m1", \
+    "evenlap_m1/hex.hypre.summary.txt" u (1e3*dx/(2**($1-1))):(1e-6*$7) w lp pt 12 lc rgb "#2ca25f" t "L_inf - EvenLap m1", \
+    "evenlap_m2/hex.hypre.summary.txt" u (1e3*dx/(2**($1-1))):(1e-6*$6) w lp pt 15 lc rgb "#756bb1" t "L_2 - EvenLap m2", \
+    "evenlap_m2/hex.hypre.summary.txt" u (1e3*dx/(2**($1-1))):(1e-6*$7) w lp pt 14 lc rgb "#756bb1" t "L_inf - EvenLap m2", \
     "orderOfAccuracySlopesStress.dat" u 1:2 w l lw 2 lc "black" notitle, \
     "orderOfAccuracySlopesStress.dat" u 1:3 w l lw 2 lc "black" notitle


### PR DESCRIPTION
Main change:
Added a sweep inside the mms to run each stabilisation method
--test case is now compatible with stabilisation frame work
--tested using hex mesh and order of accuracy was in good agreement with previous results
--A minus sign was added to the MMS sources to make them consistent with old results inside the fvOptions file
-- I still need to test this for the other kinds of meshes which I will do on xenosim